### PR TITLE
feat: implement getCurrentUser and update user info

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,6 +3,6 @@
   "useTabs": false,
   "semi": true,
   "singleQuote": true,
-  "printWidth": 100,
+  "printWidth": 80,
   "trailingComma": "all"
 }

--- a/src/common/decorators/current-user.decorator.ts
+++ b/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const CurrentUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { JWT_EXPIRES_IN, JWT_SECRET } from 'src/common/constrants/jwt.constant';
 import { PrismaModule } from 'src/prisma/prisma.module';
 import { UsersModule } from '../users/users.module';
+import { JwtStrategy } from './jwt.strategy';
 
 @Module({
   imports: [
@@ -16,7 +17,7 @@ import { UsersModule } from '../users/users.module';
     PrismaModule,
     forwardRef(() => UsersModule),
   ],
-  providers: [AuthService],
+  providers: [AuthService, JwtStrategy],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/src/modules/users/dto/update-user.dto.ts
+++ b/src/modules/users/dto/update-user.dto.ts
@@ -1,0 +1,27 @@
+import { IsEmail, IsOptional, IsString, MinLength } from 'class-validator';
+
+export class UpdateUserDto {
+  @IsOptional()
+  @IsEmail()
+  email: string;
+
+  @IsOptional()
+  @IsString()
+  username: string;
+
+  @IsOptional()
+  @MinLength(8)
+  password: string;
+
+  @IsOptional()
+  @MinLength(8)
+  passwordConfirmation: string;
+
+  @IsOptional()
+  @IsString()
+  image: string;
+
+  @IsOptional()
+  @IsString()
+  bio: string;
+}

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -1,25 +1,52 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, Put, UseGuards } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { AuthService } from '../auth/auth.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { LoginDto } from './dto/login.dto';
+import { CurrentUser } from 'src/common/decorators/current-user.decorator';
+import { User } from '@prisma/client';
+import { AuthGuard } from '@nestjs/passport';
+import { UpdateUserDto } from './dto/update-user.dto';
 
-@Controller('users')
+@Controller()
 export class UsersController {
   constructor(
     private usersService: UsersService,
     private authService: AuthService,
   ) {}
 
-  @Post()
+  @Post('users')
   async create(@Body() createUserDto: CreateUserDto) {
     const user = await this.usersService.create(createUserDto);
     return user;
   }
 
-  @Post('login')
+  @Post('users/login')
   async login(@Body() loginDto: LoginDto) {
     const user = await this.authService.login(loginDto);
     return user;
+  }
+
+  @Get('user')
+  @UseGuards(AuthGuard('jwt'))
+  async getCurrentUser(@CurrentUser() user: User) {
+    return {
+      user: {
+        email: user.email,
+        username: user.username,
+        bio: user.bio,
+        image: user.image,
+      },
+    };
+  }
+
+  @Put('user')
+  @UseGuards(AuthGuard('jwt'))
+  async update(
+    @CurrentUser() user: User,
+    @Body() updateUserDto: UpdateUserDto,
+  ) {
+    const updatedUser = await this.usersService.update(user, updateUserDto);
+    return updatedUser;
   }
 }


### PR DESCRIPTION
# Overview
This pull request includes the following key changes:
- Added @CurrentUser() decorator to extract the current user from the request.
- Protected getCurrentUser and update routes using AuthGuard to ensure only authenticated users can access them.
- Implemented two new API getCurrentUser and update.
# API Details
## Get current user
- **Endpoint**: `GET /api/user`
- **Authorization**: `Bearer <access_token>`
- **Response**:
```
{
    "user": {
        "email": "ryderthieu1234@gmail.com",
        "username": "thieuhv",
        "bio": "I like to skateboard",
        "image": "https://i.stack.imgur.com/xHWG8.jpg"
    }
}
```
## Update user info
- **Endpoint**: `PUT /api/user`
- **Authorization**: `Bearer <access_token>`
- **Request body**:
```
{
    "username": "ryderthieu1234",
    "bio": "I like anime",
}
```
- **Response**:
```
{
    "user": {
        "email": "ryderthieu1234@gmail.com",
        "username": "ryderthieu1234",
        "bio": "I like anime",
        "image": "https://i.stack.imgur.com/xHWG8.jpg"
    }
}
```

