### PR TITLE
feat: implement draft mode

### DIFF
--- a/prisma/migrations/20250730030954_add_draft_mode/migration.sql
+++ b/prisma/migrations/20250730030954_add_draft_mode/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `article` ADD COLUMN `isDraft` BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,7 @@ model Article {
   body           String
   authorId       Int
   favoritesCount Int      @default(0)
+  isDraft        Boolean  @default(false)
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 

--- a/src/modules/articles/articles.controller.ts
+++ b/src/modules/articles/articles.controller.ts
@@ -32,9 +32,31 @@ export class ArticlesController {
     return this.articlesService.create(currentUser, createArticleDto);
   }
 
+  @Get('feed')
+  @UseGuards(AuthGuard('jwt'))
+  async getFeed(
+    @Query() query: GetArticlesQueryDto,
+    @CurrentUser() currentUser: User,
+  ) {
+    return this.articlesService.getFeed(query, currentUser);
+  }
+
+  @Get('drafts')
+  @UseGuards(AuthGuard('jwt'))
+  async getDrafts(
+    @CurrentUser() currentUser: User,
+    @Query() query: GetArticlesQueryDto,
+  ) {
+    return this.articlesService.getDrafts(currentUser, query);
+  }
+
   @Get(':slug')
-  async getArticle(@Param('slug') slug: string) {
-    return this.articlesService.getArticle(slug);
+  @OptionalAuth()
+  async getArticle(
+    @Param('slug') slug: string,
+    @CurrentUser() currentUser?: User,
+  ) {
+    return this.articlesService.getArticle(slug, currentUser);
   }
 
   @Put(':slug')
@@ -78,14 +100,5 @@ export class ArticlesController {
     @CurrentUser() currentUser: User,
   ) {
     return this.articlesService.getList(query, currentUser);
-  }
-
-  @Get('feed')
-  @UseGuards(AuthGuard('jwt'))
-  async getFeed(
-    @Query() query: GetArticlesQueryDto,
-    @CurrentUser() currentUser: User,
-  ) {
-    return this.articlesService.getFeed(query, currentUser);
   }
 }

--- a/src/modules/articles/articles.service.ts
+++ b/src/modules/articles/articles.service.ts
@@ -23,8 +23,11 @@ export class ArticlesService {
     private readonly i18n: I18nService,
   ) {}
 
-  async create(currentUser: User, dto: CreateArticleDto) {
-    let slug = slugify(dto.title, { lower: true });
+  async create(currentUser: User, createArticleDto: CreateArticleDto) {
+    const slug = this.generateSlug(
+      createArticleDto.title,
+      createArticleDto.isDraft ?? false,
+    );
 
     const exists = await this.prisma.article.findUnique({ where: { slug } });
     if (exists) {
@@ -35,15 +38,16 @@ export class ArticlesService {
     const createdArticle = await this.prisma.$transaction(async (tx) => {
       const article = await tx.article.create({
         data: {
-          title: dto.title,
-          description: dto.description,
-          body: dto.body,
+          title: createArticleDto.title,
+          description: createArticleDto.description,
+          body: createArticleDto.body,
           authorId: currentUser.id,
+          isDraft: createArticleDto.isDraft ?? false,
           slug,
         },
       });
 
-      const tagList = dto.tags ?? [];
+      const tagList = createArticleDto.tags ?? [];
 
       for (const tagName of tagList) {
         const tag = await tx.tag.upsert({
@@ -68,12 +72,13 @@ export class ArticlesService {
       title: createdArticle.title,
       description: createdArticle.description,
       body: createdArticle.body,
-      tags: dto.tags,
+      tags: createArticleDto.tags,
       createdAt: createdArticle.createdAt,
       updatedAt: createdArticle.updatedAt,
       favorited: false,
       favoritesCount: 0,
       commentsCount: 0,
+      isDraft: createdArticle.isDraft,
       author: {
         username: currentUser.username,
         bio: currentUser.bio,
@@ -85,7 +90,7 @@ export class ArticlesService {
     return { article: formattedArticle };
   }
 
-  async getArticle(slug: string) {
+  async getArticle(slug: string, currentUser?: User) {
     const article = await this.prisma.article.findUnique({
       where: { slug },
       include: {
@@ -109,6 +114,11 @@ export class ArticlesService {
     });
 
     if (!article) {
+      const message = this.i18n.translate('articles.not_found');
+      throw new NotFoundException(message);
+    }
+
+    if (article.isDraft && article.authorId !== currentUser?.id) {
       const message = this.i18n.translate('articles.not_found');
       throw new NotFoundException(message);
     }
@@ -142,12 +152,31 @@ export class ArticlesService {
       throw new NotFoundException(message);
     }
 
+    if (article.isDraft && article.authorId !== currentUser.id) {
+      const message = this.i18n.translate('articles.not_found');
+      throw new NotFoundException(message);
+    }
+
     if (article.authorId !== currentUser.id) {
       const message = this.i18n.translate('articles.update_forbidden');
       throw new ForbiddenException(message);
     }
 
-    const newSlug = slugify(updateArticleDto.title, { lower: true });
+    let newSlug = article.slug;
+    if (updateArticleDto.title) {
+      newSlug = this.generateSlug(
+        updateArticleDto.title,
+        updateArticleDto.isDraft ?? false,
+      );
+    }
+
+    if (
+      article.isDraft &&
+      !updateArticleDto.isDraft &&
+      !updateArticleDto.title
+    ) {
+      newSlug = this.generateSlug(article.title, false);
+    }
 
     if (newSlug !== article.slug) {
       const existing = await this.prisma.article.findUnique({
@@ -166,6 +195,7 @@ export class ArticlesService {
           title: updateArticleDto.title,
           description: updateArticleDto.description,
           body: updateArticleDto.body,
+          isDraft: updateArticleDto.isDraft,
           slug: newSlug,
         },
       });
@@ -242,6 +272,7 @@ export class ArticlesService {
       favorited: !!favorited,
       favoritesCount: currentArticle.favoritesCount,
       commentsCount: commentsCount,
+      isDraft: currentArticle.isDraft,
       author: {
         username: currentUser.username,
         bio: currentUser.bio,
@@ -473,7 +504,7 @@ export class ArticlesService {
       offset = DEFAULT_OFFSET,
     } = query;
 
-    const where: any = {};
+    const where: any = { isDraft: false };
 
     if (tag) {
       where.tags = {
@@ -570,6 +601,7 @@ export class ArticlesService {
           favorited: !!favourited,
           favoritesCount: article.favoritesCount,
           commentsCount: commentsCount,
+          isDraft: article.isDraft,
           author: {
             username: article.author.username,
             bio: article.author.bio,
@@ -595,6 +627,7 @@ export class ArticlesService {
     const [articles, total] = await this.prisma.$transaction([
       this.prisma.article.findMany({
         where: {
+          isDraft: false,
           author: {
             followers: {
               some: {
@@ -668,6 +701,7 @@ export class ArticlesService {
           favorited: !!favourited,
           favoritesCount: article.favoritesCount,
           commentsCount: commentsCount,
+          isDraft: article.isDraft,
           author: {
             username: article.author.username,
             bio: article.author.bio,
@@ -685,5 +719,57 @@ export class ArticlesService {
       limit,
       totalOffset: Math.ceil(total / limit),
     };
+  }
+
+  async getDrafts(currentUser: User, query: GetArticlesQueryDto) {
+    const { limit = DEFAULT_LIMIT, offset = DEFAULT_OFFSET } = query;
+
+    const [drafts, total] = await this.prisma.$transaction([
+      this.prisma.article.findMany({
+        where: {
+          isDraft: true,
+          authorId: currentUser.id,
+        },
+        take: limit,
+        skip: offset,
+        orderBy: {
+          createdAt: 'desc',
+        },
+        select: {
+          id: true,
+          title: true,
+          slug: true,
+          createdAt: true,
+          updatedAt: true,
+          isDraft: true,
+        },
+      }),
+      this.prisma.article.count({
+        where: {
+          isDraft: true,
+          authorId: currentUser.id,
+        },
+      }),
+    ]);
+    if (!drafts) {
+      const message = this.i18n.translate('articles.not_found');
+      throw new NotFoundException(message);
+    }
+
+    return {
+      articles: drafts,
+      articlesCount: total,
+      offset,
+      limit,
+      totalOffset: Math.ceil(total / limit),
+    };
+  }
+
+  generateSlug(title: string, isDraft: boolean): string {
+    let slug = slugify(title, { lower: true });
+    if (isDraft) {
+      slug = `${slug}-${Date.now()}-draft`;
+    }
+    return slug;
   }
 }

--- a/src/modules/articles/dto/create-article.dto.ts
+++ b/src/modules/articles/dto/create-article.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsOptional, IsString } from 'class-validator';
+import { IsArray, IsBoolean, IsOptional, IsString } from 'class-validator';
 
 export class CreateArticleDto {
   @IsString()
@@ -14,4 +14,8 @@ export class CreateArticleDto {
   @IsArray()
   @IsString({ each: true })
   tags?: string[];
+
+  @IsOptional()
+  @IsBoolean()
+  isDraft?: boolean;
 }

--- a/src/modules/articles/dto/update-article.dto.ts
+++ b/src/modules/articles/dto/update-article.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsOptional, IsString } from 'class-validator';
+import { IsArray, IsBoolean, IsOptional, IsString } from 'class-validator';
 
 export class UpdateArticleDto {
   @IsOptional()
@@ -17,4 +17,8 @@ export class UpdateArticleDto {
   @IsArray()
   @IsString({ each: true })
   tags: string[];
+
+  @IsOptional()
+  @IsBoolean()
+  isDraft: boolean;
 }


### PR DESCRIPTION
# Overview
- Add `isDraft` field to `article` table
- Add `isDraft` field to `article` response
- Implement `getDrafts` API to get user's drafts articles
# API details
- **Endpoint**: `GET /api/articles/drafts`
- **Authentication**: Required
- **Param**: `limit`, `offset`
```
{
    "articles": [
        {
            "id": 4,
            "title": "How to train your dragon",
            "slug": "how-to-train-your-dragon-1753847631253-draft",
            "createdAt": "2025-07-30T03:53:51.256Z",
            "updatedAt": "2025-07-30T03:53:51.256Z",
            "isDraft": true
        },
        {
            "id": 3,
            "title": "How to train your dragon",
            "slug": "how-to-train-your-dragon-1753847630363-draft",
            "createdAt": "2025-07-30T03:53:50.368Z",
            "updatedAt": "2025-07-30T03:53:50.368Z",
            "isDraft": true
        }
    ],
    "articlesCount": 3,
    "offset": 0,
    "limit": 2,
    "totalOffset": 2
}
```