### PR TITLE
feat: implement article stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
+        "date-fns": "^4.1.0",
         "nestjs-i18n": "^10.5.1",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
@@ -5872,6 +5873,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "date-fns": "^4.1.0",
     "nestjs-i18n": "^10.5.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",

--- a/src/common/constrants/stats.constant.ts
+++ b/src/common/constrants/stats.constant.ts
@@ -1,0 +1,1 @@
+export const MIN_INTERACTIONS_DEFAULT = 50;

--- a/src/modules/articles/articles.controller.ts
+++ b/src/modules/articles/articles.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -17,6 +18,7 @@ import { CreateArticleDto } from './dto/create-article.dto';
 import { UpdateArticleDto } from './dto/update-article.dto';
 import { GetArticlesQueryDto } from './dto/get-articles-query.dto';
 import { OptionalAuth } from 'src/common/decorators/optional-auth.decorator';
+import { MIN_INTERACTIONS_DEFAULT } from 'src/common/constrants/stats.constant';
 
 @Controller('articles')
 export class ArticlesController {
@@ -48,6 +50,21 @@ export class ArticlesController {
     @Query() query: GetArticlesQueryDto,
   ) {
     return this.articlesService.getDrafts(currentUser, query);
+  }
+
+  @Get('stats')
+  @UseGuards(AuthGuard('jwt'))
+  async stats(
+    @CurrentUser() currentUser: User,
+    @Query('minInteractions') minInteractions: number,
+  ) {
+    if (isNaN(minInteractions)) {
+      throw new BadRequestException('Invalid min interaction');
+    }
+    return this.articlesService.stats(
+      currentUser,
+      minInteractions ?? MIN_INTERACTIONS_DEFAULT,
+    );
   }
 
   @Get(':slug')

--- a/src/modules/articles/articles.service.ts
+++ b/src/modules/articles/articles.service.ts
@@ -15,6 +15,13 @@ import {
   DEFAULT_OFFSET,
 } from 'src/common/constrants/pagination.constant';
 import { I18nService } from 'nestjs-i18n';
+import {
+  addMonths,
+  endOfMonth,
+  format,
+  isBefore,
+  startOfMonth,
+} from 'date-fns';
 
 @Injectable()
 export class ArticlesService {
@@ -762,6 +769,50 @@ export class ArticlesService {
       offset,
       limit,
       totalOffset: Math.ceil(total / limit),
+    };
+  }
+
+  async stats(currentUser: User, minInteractions: number) {
+    const startDate = startOfMonth(currentUser.createdAt);
+    const endDate = endOfMonth(new Date());
+
+    const stats = new Map<string, number>();
+    let current = startDate;
+
+    while (!isBefore(endDate, current)) {
+      const key = format(current, 'yyyy-MM');
+      stats.set(key, 0);
+      current = addMonths(current, 1);
+    }
+
+    const articles = await this.prisma.article.findMany({
+      where: {
+        authorId: currentUser.id,
+        createdAt: { gte: startDate, lte: endDate },
+      },
+      select: {
+        id: true,
+        favorites: true,
+        comments: true,
+        createdAt: true,
+      },
+    });
+
+    for (const article of articles) {
+      if (
+        article.comments.length + article.favorites.length >=
+        minInteractions
+      ) {
+        const key = format(article.createdAt, 'yyyy-MM');
+        stats.set(key, (stats.get(key) || 0) + 1);
+      }
+    }
+
+    return {
+      stats: Array.from(stats.entries()).map(([month, count]) => ({
+        month,
+        count,
+      })),
     };
   }
 


### PR DESCRIPTION
# Overview
- Implement articles stats API to get number of articles with min interactions every month
# API details
- **Endpoint**: `GET /api/articles/stats`
- **Authentication**: Required
- **Param**: `minInteractions`
```json
{
    "stats": [
        {
            "month": "2025-07",
            "count": 1
        }
    ]
}
```